### PR TITLE
Fix subdomain names

### DIFF
--- a/packages/docusaurus/docs/02-Getting Started/03-quick-install.md
+++ b/packages/docusaurus/docs/02-Getting Started/03-quick-install.md
@@ -47,7 +47,7 @@ sudo ./installer
 The installer will prompt you for the following basic information. For example:
 
 1. **Base Domain Name**: Enter your base fully qualified domain name (without any subdomains) Example: `example.com`
-2. **Dashboard Domain Name**: The domain where the application will be hosted. This is used for many things, including generating links. You can run Pangolin on a subdomain or root domain. Example: `proxy.example.com`
+2. **Dashboard Domain Name**: The domain where the application will be hosted. This is used for many things, including generating links. You can run Pangolin on a subdomain or root domain. Example: `pangolin.example.com`
 3. **Let's Encrypt Email**: Provide an email address for SSL certificate registration with Lets Encrypt. This should be an email you have access to.
 4. **Tunneling** You can choose not to install Gerbil for tunneling support - in this config it will just be a normal reverse proxy. See [how to use without tunneling](/03-Pangolin/03-without-tunneling.md).
 

--- a/packages/docusaurus/docs/03-Pangolin/02-Configuration/02-config.md
+++ b/packages/docusaurus/docs/03-Pangolin/02-Configuration/02-config.md
@@ -7,7 +7,7 @@ Pangolin is configured using a `config.yml` file. The file is expected to be mou
 ### `app`
 
 - `dashboard_url`: string
-    - Example: `https://example.com` or `https://proxy.example.com`
+    - Example: `https://example.com` or `https://pangolin.example.com`
     - The url where the application is hosted. This is used for many things, including generating links.
     - You can run Pangolin on a subdomain or root domain. Users will be redirected to this url to complete the auth step.
 - `log_level`: string
@@ -45,7 +45,7 @@ Pangolin is configured using a `config.yml` file. The file is expected to be mou
 - `cors`: object (optional)
     - Configuration for Cross-Origin Resource Sharing (CORS).
     - `origins`: array of strings (optional)
-        - Example: `["https://proxy.example.com"]`
+        - Example: `["https://pangolin.example.com"]`
         - List of allowed origins for cross-origin requests.
     - `methods`: array of strings (optional)
         - Example: `["GET", "POST", "PUT", "DELETE", "PATCH"]`

--- a/packages/docusaurus/src/components/DynamicTraefikConfig.tsx
+++ b/packages/docusaurus/src/components/DynamicTraefikConfig.tsx
@@ -12,7 +12,7 @@ const DynamicTraefikConfig: React.FC = () => {
   routers:
     # HTTP to HTTPS redirect router
     main-app-router-redirect:
-      rule: "Host(\`proxy.example.com\`)" # REPLACE THIS WITH YOUR DOMAIN
+      rule: "Host(\`pangolin.example.com\`)" # REPLACE THIS WITH YOUR DOMAIN
       service: next-service
       entryPoints:
         - web
@@ -21,7 +21,7 @@ const DynamicTraefikConfig: React.FC = () => {
 
     # Next.js router (handles everything except API and WebSocket paths)
     next-router:
-      rule: "Host(\`proxy.example.com\`) && !PathPrefix(\`/api/v1\`)" # REPLACE THIS WITH YOUR DOMAIN
+      rule: "Host(\`pangolin.example.com\`) && !PathPrefix(\`/api/v1\`)" # REPLACE THIS WITH YOUR DOMAIN
       service: next-service
       entryPoints:
         - websecure
@@ -30,7 +30,7 @@ const DynamicTraefikConfig: React.FC = () => {
 
     # API router (handles /api/v1 paths)
     api-router:
-      rule: "Host(\`proxy.example.com\`) && PathPrefix(\`/api/v1\`)" # REPLACE THIS WITH YOUR DOMAIN
+      rule: "Host(\`pangolin.example.com\`) && PathPrefix(\`/api/v1\`)" # REPLACE THIS WITH YOUR DOMAIN
       service: api-service
       entryPoints:
         - websecure
@@ -39,7 +39,7 @@ const DynamicTraefikConfig: React.FC = () => {
 
     # WebSocket router
     ws-router:
-      rule: "Host(\`proxy.example.com\`)" # REPLACE THIS WITH YOUR DOMAIN
+      rule: "Host(\`pangolin.example.com\`)" # REPLACE THIS WITH YOUR DOMAIN
       service: api-service
       entryPoints:
         - websecure

--- a/packages/docusaurus/src/components/DynamicTraefikConfig.tsx
+++ b/packages/docusaurus/src/components/DynamicTraefikConfig.tsx
@@ -12,7 +12,7 @@ const DynamicTraefikConfig: React.FC = () => {
   routers:
     # HTTP to HTTPS redirect router
     main-app-router-redirect:
-      rule: "Host(\`pangolin.example.com\`)" # REPLACE THIS WITH YOUR DOMAIN
+      rule: "Host(\`proxy.example.com\`)" # REPLACE THIS WITH YOUR DOMAIN
       service: next-service
       entryPoints:
         - web
@@ -21,7 +21,7 @@ const DynamicTraefikConfig: React.FC = () => {
 
     # Next.js router (handles everything except API and WebSocket paths)
     next-router:
-      rule: "Host(\`pangolin.example.com\`) && !PathPrefix(\`/api/v1\`)" # REPLACE THIS WITH YOUR DOMAIN
+      rule: "Host(\`proxy.example.com\`) && !PathPrefix(\`/api/v1\`)" # REPLACE THIS WITH YOUR DOMAIN
       service: next-service
       entryPoints:
         - websecure
@@ -30,7 +30,7 @@ const DynamicTraefikConfig: React.FC = () => {
 
     # API router (handles /api/v1 paths)
     api-router:
-      rule: "Host(\`pangolin.example.com\`) && PathPrefix(\`/api/v1\`)" # REPLACE THIS WITH YOUR DOMAIN
+      rule: "Host(\`proxy.example.com\`) && PathPrefix(\`/api/v1\`)" # REPLACE THIS WITH YOUR DOMAIN
       service: api-service
       entryPoints:
         - websecure


### PR DESCRIPTION
I had a problem setting up pangolin. From the example in this file, I had assumed that two different subdomains were needed. I was able to access the pangolin dashboard using the same subdomain name. 

Looking through the history, I found that before commit 05e11cf this example was as in my change. 