### PR TITLE
docs: replaced old docker-compose command

### DIFF
--- a/packages/docusaurus/docs/03-Pangolin/05-tcp-udp.md
+++ b/packages/docusaurus/docs/03-Pangolin/05-tcp-udp.md
@@ -82,6 +82,6 @@ entryPoints:
 After you've made all of the changes above, you need to restart the stack. This can be done with the following command:
 
 ```bash
-sudo docker-compose down
-sudo docker-compose up -d
+sudo docker compose down
+sudo docker compose up -d
 ```


### PR DESCRIPTION
replace old `docker-compose` command with `docker compose` to follow the standard of the rest of the documentation.

Thanks