### PR TITLE
Adjust Docker port exposure warning.

### DIFF
--- a/packages/docusaurus/docs/02-Getting Started/02-dns-networking.md
+++ b/packages/docusaurus/docs/02-Getting Started/02-dns-networking.md
@@ -39,37 +39,59 @@ If you intend to use the root of your domain, then you will need an additional A
 ## Ports to Expose
 
 :::warning
+Docker automatically creates iptables NAT rules when container ports are published (using `-p` or in docker-compose via `ports:`), which can bypass host firewall settings such as [UFW](https://en.wikipedia.org/wiki/Uncomplicated_Firewall) or [firewalld](https://en.wikipedia.org/wiki/Firewalld). This may cause ports to be accessible from external networks even if they aren’t explicitly allowed by your firewall.
 
-**Docker Port Exposure Caveat:**  
-Docker automatically creates iptables NAT rules when container ports are published (using `-p` or docker-compose). These rules can bypass host firewall settings (such as UFW or firewalld), causing ports to be accessible from external networks even if they aren’t explicitly allowed by your firewall. Always verify your exposed ports (e.g., with [nmap](https://nmap.org/) or [RustScan](https://github.com/bee-san/RustScan)) and ensure you only expose the ports that are absolutely necessary. For more details, see [Docker’s port publishing documentation](https://docs.docker.com/engine/network/packet-filtering-firewalls/#port-publishing-and-mapping).
+**Mitigation:** For ports that should not be exposed externally, consider binding them on the host to the loopback interface (i.e., `127.0.0.1`) in your docker-compose configuration. For example, instead of using:
 
+```yaml
+ports:
+  - "8080:8080"
+```
+
+you can restrict the exposure only to localhost interface with:
+
+```yaml
+ports:
+  - "127.0.0.1:8080:8080"
+```
+
+This approach limits access to that port only to the host machine. Note that this method is not suitable for all exposed ports—use it only for those services that should remain internal.
+
+Always verify your exposed ports (e.g., with [nmap](https://nmap.org/) or [RustScan](https://github.com/bee-san/RustScan)) and ensure you expose **only** the ports that are absolutely necessary. By tunneling out to the VPS, you are effectively including the VPS in your security boundary, so you must secure it as part of your overall network strategy. For more details, see [Docker’s port publishing documentation](https://docs.docker.com/engine/network/packet-filtering-firewalls/#port-publishing-and-mapping).
 :::
 
-Following ports should be exposed on Operating system level.
+
+For Pangolin to work correctly, the following ports must be open at the operating system level and exposed on all or external interfaces (i.e., bound to `0.0.0.0`).
 
 ### TCP 80
 
-If you are using HTTP SSL verification (default from the installer) then Lets Encrypt will try to reach Traefik on this port to verify the subdomain. Non SSL resources will also use this port.
+If you are using HTTP SSL verification (default from the installer), Let's Encrypt will attempt to reach Traefik on this port to verify the subdomain. Additionally, non-SSL resources will use this port.
 
 :::note
-
-If you use wildcard certificates with `DNS-01` verification, you can disable this port. Only the `443` port will be needed.
-
+If you use wildcard certificates with `DNS-01` verification, you can disable this port; only the `443` port will then be needed.
 :::
 
 ### TCP 443
 
-The Pangolin web UI and SSL resources use this port to connect with HTTPS.
+The Pangolin web UI and SSL resources use this port to establish secure HTTPS connections. This port is essential and must be available on all network interfaces.
 
 ### UDP 51820
 
-This is the default WireGuard port and is used for Newt and WireGuard clients to connect to Gerbil. If you change this in the config file then you would use that port.
+This is the default WireGuard port and is used for Newt and WireGuard clients to connect to Gerbil. If you change this in the configuration file, use the new port accordingly. This port is also essential and must be available on all network interfaces.
 
-:::warning
+### Correctly exposed Pangolin's ports
 
-Its important to **ONLY** expose and verify exposed the ports you need. Effectively by tunneling out to the VPS you are including the VPS in your security boundary and should consider it part of your network and secure it as such.
+By default the config defaults to using the bellow settings that these ports are exposed on all interfaces:
 
-:::
+```yaml
+gerbil:
+  ports:
+    - "80:80"        # TCP port for HTTP/SSL verification and non-SSL resources
+    - "443:443"      # TCP port for HTTPS, necessary for the Pangolin web UI and SSL resources
+    - "51820:51820"  # UDP port for WireGuard, used by Newt and WireGuard clients
+```
+
+Ensure that your host firewall settings allow incoming connections on these ports.
 
 ## Default Internal Subnet
 

--- a/packages/docusaurus/docs/02-Getting Started/03-quick-install.md
+++ b/packages/docusaurus/docs/02-Getting Started/03-quick-install.md
@@ -9,7 +9,7 @@ import WgetQuickInstaller from "@site/src/components/WgetQuickInstaller";
   - We recommend Ubuntu or Debian based systems
 - [A domain name pointed to your server's IP address](./02-dns-networking.md)
 - [TCP ports 80, 443, and UDP port 51820 exposed to your Linux instance.](./02-dns-networking.md)
-  - **Note:** Docker’s NAT-based port publishing feature automatically exposes all ports defined in `docker-compose` file. This behavior can bypass your host firewall settings, potentially exposing services that you did not intend to make public. It is important to review and manage these port configurations to minimize security risks.
+  - **Note:** Docker’s NAT-based port publishing feature automatically exposes all `ports:` defined in `docker-compose` file on all network interfaces. This behavior can bypass your host firewall settings, potentially exposing services that you did not intend to make public. Please see [complete warning about exposing ports](/Getting%20Started/dns-networking#ports-to-expose).
 - An email address for Let's Encrypt certificate registration
 - (Optionally) a SMTP server
 

--- a/packages/docusaurus/docs/02-Getting Started/04-Manual Install Guides/01-docker-compose.md
+++ b/packages/docusaurus/docs/02-Getting Started/04-Manual Install Guides/01-docker-compose.md
@@ -18,6 +18,7 @@ This guide will walk you through setting up the Docker Compose stack manually wi
   - We recommend Ubuntu or Debian based systems
 - [A domain name pointed to your server's IP address](../02-dns-networking.md)
 - [TCP ports 80, 443, and UDP port 51820 exposed to your Linux instance.](../02-dns-networking.md)
+  - **Note:** Docker’s NAT-based port publishing feature automatically exposes all `ports:` defined in `docker-compose` file on all network interfaces. This behavior can bypass your host firewall settings, potentially exposing services that you did not intend to make public. Please see [complete warning about exposing ports](/Getting%20Started/dns-networking#ports-to-expose).
 - An email address for Let's Encrypt certificate registration
 - (Optionally) a SMTP server
 

--- a/packages/docusaurus/docs/03-Pangolin/04-tcp-udp.md
+++ b/packages/docusaurus/docs/03-Pangolin/04-tcp-udp.md
@@ -36,6 +36,10 @@ gerbil:
     - 1704:1704/udp # ADDED
     - 1602:1602 # ADDED
 ```
+:::warning
+Docker’s NAT-based port publishing feature automatically exposes all `ports:` defined in the `docker-compose` file on all network interfaces. This behavior can bypass your host firewall settings, potentially exposing services that you did not intend to make public.
+Please see [complete warning about exposing ports](/Getting%20Started/dns-networking#ports-to-expose).
+:::
 
 ## Configuring Traefik
 

--- a/packages/docusaurus/docs/07-Modules/02-crowdsec.md
+++ b/packages/docusaurus/docs/07-Modules/02-crowdsec.md
@@ -107,9 +107,13 @@ systemctl restart crowdsec-firewall-bouncer
 service:
   crowdsec:
     ports:
-      - 6060:6060
-      - 8080:8080
+      - 6060:6060 # Metrics port
+      - 8080:8080 # Local API port
 ```
+:::warning
+Docker’s NAT-based port publishing feature automatically exposes all `ports:` defined in the `docker-compose` file on all network interfaces. This behavior can bypass your host firewall settings, potentially exposing services that you did not intend to make public.
+Please see [complete warning about exposing ports](/Getting%20Started/dns-networking#ports-to-expose).
+:::
 
 7. Verify communication between the firewall bouncer and the CrowdSec container by running:
 

--- a/packages/docusaurus/docs/07-Modules/04-metrics.md
+++ b/packages/docusaurus/docs/07-Modules/04-metrics.md
@@ -23,6 +23,10 @@ service:
     ports:
       - 8082:8082
 ```
+:::warning
+Docker’s NAT-based port publishing feature automatically exposes all `ports:` defined in `docker-compose` file. This behavior can bypass your host firewall settings, potentially exposing services that you did not intend to make public.
+Please see [complete warning about exposing ports](/Getting%20Started/dns-networking#ports-to-expose).
+:::
 
 2. Update the `/config/traefik/traefik_config.yml` file to include the following:
 
@@ -62,6 +66,11 @@ service:
     ports:
       - 6060:6060
 ```
+:::warning
+Docker’s NAT-based port publishing feature automatically exposes all `ports:` defined in the `docker-compose` file on all network interfaces. This behavior can bypass your host firewall settings, potentially exposing services that you did not intend to make public.
+Please see [complete warning about exposing ports](/Getting%20Started/dns-networking#ports-to-expose).
+:::
+
 
 2. Restart the Crowdsec container to apply the changes:
 
@@ -87,6 +96,11 @@ services:
       - ./config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./config/prometheus/data:/prometheus
 ```
+:::warning
+Docker’s NAT-based port publishing feature automatically exposes all `ports:` defined in the `docker-compose` file on all network interfaces. This behavior can bypass your host firewall settings, potentially exposing services that you did not intend to make public.
+Please see [complete warning about exposing ports](/Getting%20Started/dns-networking#ports-to-expose).
+:::
+
 
 2. Create a `prometheus.yml` file in the `/config/prometheus` directory with the following content:
 
@@ -138,6 +152,10 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ./config/grafana/data:/var/lib/grafana
 ```
+:::warning
+Docker’s NAT-based port publishing feature automatically exposes all `ports:` defined in the `docker-compose` file on all network interfaces. This behavior can bypass your host firewall settings, potentially exposing services that you did not intend to make public.
+Please see [complete warning about exposing ports](/Getting%20Started/dns-networking#ports-to-expose).
+:::
 
 2. Start the Grafana container:
 


### PR DESCRIPTION
### Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

This is enhancement of previous PR https://github.com/fosrl/docs/pull/13

With this PR, changes are following:
- Adjust Docker port exposure warning.
- Add short warning under each code snippet where docker-compose ports are modified with link to longer version of warning located at dns-networking#ports-to-expose.
- Rewrite the Port section in Getting Started guide with additional information that Pangolins' defaults ports 80, 443 and 51820 should be exposed on all interfaces.
- Added mittigation controls and how to bind ports to localhost only if applicable