### PR TITLE
Fix: Get raw ban/captcha html files instead of full Github browsing pages

### DIFF
--- a/packages/docusaurus/docs/07-Community Guides/02-crowdsec.md
+++ b/packages/docusaurus/docs/07-Community Guides/02-crowdsec.md
@@ -148,7 +148,7 @@ To display a custom ban page to attackers, follow these steps:
 1. Place a `ban.html` page in the `/config/traefik` directory. If you prefer not to create your own, you can download the official example:
 
 ```bash
-wget https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/blob/main/ban.html
+wget https://raw.githubusercontent.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/refs/heads/main/ban.html
 ```
 
 2. Update the `/config/traefik/dynamic_config.yml` file to include the following:
@@ -169,7 +169,7 @@ To use a custom captcha page, follow these steps:
 1. Place a `captcha.html` page in the `/config/traefik` directory. If you don't want to create your own, you can download the official example:
 
 ```bash
-wget https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/blob/main/captcha.html
+wget https://raw.githubusercontent.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/refs/heads/main/captcha.html
 ```
 
 2. Update the `/config/traefik/dynamic_config.yml` file with the following configuration, replacing `<SERVICE>` with your captcha provider (e.g. hCaptcha, reCaptcha, Turnstile), and `<KEY>` with the appropriate site and secret keys:


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
I was following the community guide to add my own ban and captcha pages to Crowdsec, and I noticed that the example `wget` commands downloaded the entire Github file browser page (or whatever it's called) instead of just the HTML files.

This just changes those links to the raw content links.