### PR TITLE
Crowdsec Community Guide Fixes

### DIFF
--- a/packages/docusaurus/docs/07-Community Guides/02-crowdsec.md
+++ b/packages/docusaurus/docs/07-Community Guides/02-crowdsec.md
@@ -172,7 +172,7 @@ To use a custom captcha page, follow these steps:
 wget https://raw.githubusercontent.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/refs/heads/main/captcha.html
 ```
 
-2. Update the `/config/traefik/dynamic_config.yml` file with the following configuration, replacing `<SERVICE>` with your captcha provider (e.g. hCaptcha, reCaptcha, Turnstile), and `<KEY>` with the appropriate site and secret keys:
+2. Update the `/config/traefik/dynamic_config.yml` file with the following configuration, replacing `<SERVICE>` with your captcha provider (MUST BE either `hcaptcha`, `recaptcha`, or `turnstile`), and `<KEY>` with the appropriate site and secret keys:
 
 ```yaml
 http:

--- a/packages/docusaurus/docs/07-Community Guides/02-crowdsec.md
+++ b/packages/docusaurus/docs/07-Community Guides/02-crowdsec.md
@@ -148,7 +148,7 @@ To display a custom ban page to attackers, follow these steps:
 1. Place a `ban.html` page in the `/config/traefik` directory. If you prefer not to create your own, you can download the official example:
 
 ```bash
-wget https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/blob/main/ban.html
+wget https://raw.githubusercontent.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/refs/heads/main/ban.html
 ```
 
 2. Update the `/config/traefik/dynamic_config.yml` file to include the following:
@@ -169,7 +169,7 @@ To use a custom captcha page, follow these steps:
 1. Place a `captcha.html` page in the `/config/traefik` directory. If you don't want to create your own, you can download the official example:
 
 ```bash
-wget https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/blob/main/captcha.html
+wget https://raw.githubusercontent.com/maxlerebourg/crowdsec-bouncer-traefik-plugin/refs/heads/main/captcha.html
 ```
 
 2. Update the `/config/traefik/dynamic_config.yml` file with the following configuration, replacing `<SERVICE>` with your captcha provider (e.g. hCaptcha, reCaptcha, Turnstile), and `<KEY>` with the appropriate site and secret keys:


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
I just went through the process of setting up Crowdsec with my Pangolin install and found a few issues with the Crowdsec community guide.

First, the `wget` commands for the example HTML files (for the ban and captcha pages) point to the Github browser (or whatever they're called) pages instead of the raw file content. This results in wget downloading the entire GitHub page, not just the file. I changed the links to the raw content links.

Secondly, the guide doesn't specify that the CAPTCHA provider names MUST be exactly `hcaptcha`, `recaptcha`, or `turnstile`, or else Traefik will freak out and return a 404 for every page on your proxy. This happened to me, and luckily, the logs tell you this, but I figured this should be included in the guide.

These aren't huge issues, but they could definitely confuse some people. I haven't followed the instructions in the "Securing the Host System (SSH)" section, so I'm not sure if there are any small mistakes like these there.