### PR TITLE
Add warning regarding Unraid Gerbil WireGuard port

### DIFF
--- a/packages/docusaurus/docs/02-Getting Started/04-Manual Install Guides/02-unraid.md
+++ b/packages/docusaurus/docs/02-Getting Started/04-Manual Install Guides/02-unraid.md
@@ -216,6 +216,21 @@ WireGuard Port:
 
 The port you use for WireGuard must also match what you set the port to in the Pangolin config. By default we use a slightly different port than the standard WireGuard port to avoid conflicts with the built in WireGuard server in Unraid.
 
+:::warning
+
+You **must** use the default port of `51822` for WireGuard in the Gerbil container. Using any other port may cause connection issues that are difficult to debug.
+
+Make sure this is also reflected in your Pangolin `config.yml`:
+
+```yml
+gerbil:
+  start_port: 51822
+```
+
+See [this GitHub issue comment](https://github.com/fosrl/pangolin/issues/227#issuecomment-2781608815) for more details.
+
+:::
+
 HTTP and HTTPS Ports:
 
 You must open these ports because Traefik will be routed through Gerbil. These ports should match the ports you set in the Traefik config earlier. In the next step, we will set the network mode for Traefik which which will close the ports on the Traeffik side, and prevent conflicts. Before doing this, if you start the Traefik container at the same time as the Gerbil container with the same ports mapped to the host, you will get an error.


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description
I have debugged an issue for 10-15 cumulative hours and I finally found the solution. The idea came to mind from reading [this GitHub issue comment](https://github.com/fosrl/pangolin/issues/227#issuecomment-2781608815). Apparently the Gerbil Docker container internally does not like having different internal and external ports, it wants them to be matched.

I tried port `51820`, `51824`, `1194`, all of them responded to `tcpdump -i any -n udp port [PORT]` tests (confirming UDP packets were reaching the server when testing with `echo "poke" | nc -u [IP] [PORT]`), but I still had no Newt containers being able to connect.

My `51822` port was busy by another user on my network so that's why it took me so long to try the default setting, but once I did everything instantly worked.

The issue was so obscure that even with great Discord support (thanks Astral), it was very hard to identify. For now, the earliest and easiest thing to do is at least notify any future user where an issue might occur, until it is hopefully fixed in the system itself later on.